### PR TITLE
Don't use 'ORDER BY' and 'LIMIT' in 'DELETE' query

### DIFF
--- a/autoqueue/request.py
+++ b/autoqueue/request.py
@@ -42,6 +42,6 @@ class Requests(object):
 
     def pop(self, filename):
         self.cursor.execute(
-            "DELETE FROM requests WHERE filename = ? ORDER BY id LIMIT 1;",
+            "DELETE FROM requests WHERE id IN (SELECT id from requests where filename = ? ORDER BY id LIMIT 1);",
             (filename,))
         self.connection.commit()


### PR DESCRIPTION
Sqlite can't directly handle 'ORDER BY' and 'LIMIT' clauses in 'DELETE'
queries. At least not unless sqlite is specifically compiled for it.

See <http://www.sqlite.org/lang_delete.html> under "Optional LIMIT and
ORDER BY clauses".